### PR TITLE
Adding the Channel Class to the CrystalDiscord Library

### DIFF
--- a/src/discord/channel.cr
+++ b/src/discord/channel.cr
@@ -1,1 +1,30 @@
 require "json"
+require "./http"
+require "../crystaldiscord"
+
+class Crystaldiscord::Channel
+  @http : Crystaldiscord::HTTPClient
+  property id : String
+  property name : String
+  property type : Int32
+  property topic : String
+  property guild_id : String
+  property nsfw : Bool
+  property members : Array(Crystaldiscord::Member)
+
+  def initialize(@http, @id, @name, @topic, @guild_id, @members)
+  end
+
+  def Channel.from_json_object(data : JSON::Any, http : Crystaldiscord::HTTPClient)
+    id = data["id"].as_s
+    type = data["type"].as_i32
+    name = data["name"].as_s
+    topic = data["topic"].as_s
+    guild_id = data["guild_id"].as_s
+    nsfw = data["nsfw"].as_b
+    members = data["members"].as_a.map do |member|
+      Crystaldiscord::Member.from_json_object(member, http)
+    end
+    return Channel.new http, id, type, name, topic, guild_id, nsfw, members
+  end
+end

--- a/src/discord/channel.cr
+++ b/src/discord/channel.cr
@@ -12,7 +12,7 @@ class Crystaldiscord::Channel
   property nsfw : Bool
   property members : Array(Crystaldiscord::Member)
 
-  def initialize(@http, @id, @name, @topic, @guild_id, @members)
+  def initialize(@http, @id, @name, @type, @topic, @guild_id, @nsfw, @members)
   end
 
   def Channel.from_json_object(data : JSON::Any, http : Crystaldiscord::HTTPClient)


### PR DESCRIPTION
## Proposed Changes:

- Added the `Channel` class to the CrystalDiscord module.
- Included the `type` property in the `Channel` class.

This pull request introduces the `Channel` class to the CrystalDiscord library, providing a basic structure for representing Discord channels.

## Additional Notes:
Please make sure to review and adjust as needed before merging. Testing the code was not possible at this time.

I understand that this library has been without an update for years, and I truly appreciate your initiative in contributing. Unfortunately, it seems that this pull request may go unnoticed or unaccepted. Nonetheless, know that I admire your effort towards the library, and it's a shame that it apparently didn't work out. 😔